### PR TITLE
Add SOCKET_RELAYER_ROLE

### DIFF
--- a/contracts/ExecutionManager.sol
+++ b/contracts/ExecutionManager.sol
@@ -6,7 +6,7 @@ import "./interfaces/ISocket.sol";
 import "./interfaces/ISignatureVerifier.sol";
 import "./libraries/RescueFundsLib.sol";
 import "./utils/AccessControlExtended.sol";
-import {WITHDRAW_ROLE, RESCUE_ROLE, EXECUTOR_ROLE, FEES_UPDATER_ROLE} from "./utils/AccessRoles.sol";
+import {WITHDRAW_ROLE, RESCUE_ROLE, EXECUTOR_ROLE, FEES_UPDATER_ROLE, SOCKET_RELAYER_ROLE} from "./utils/AccessRoles.sol";
 import {FEES_UPDATE_SIG_IDENTIFIER, RELATIVE_NATIVE_TOKEN_PRICE_UPDATE_SIG_IDENTIFIER, MSG_VALUE_MAX_THRESHOLD_SIG_IDENTIFIER, MSG_VALUE_MIN_THRESHOLD_SIG_IDENTIFIER} from "./utils/SigIdentifiers.sol";
 
 /**
@@ -224,6 +224,7 @@ contract ExecutionManager is IExecutionManager, AccessControlExtended {
         external
         payable
         override
+        onlyRole(SOCKET_RELAYER_ROLE)
         returns (uint128 executionFee, uint128 transmissionFees)
     {
         if (msg.value >= type(uint128).max) revert InvalidMsgValue();
@@ -568,7 +569,7 @@ contract ExecutionManager is IExecutionManager, AccessControlExtended {
         uint32 siblingChainSlug_,
         address switchboard_,
         uint128 amount_
-    ) external override {
+    ) external override onlyRole(SOCKET_RELAYER_ROLE) {
         if (totalSwitchboardFees[switchboard_][siblingChainSlug_] < amount_)
             revert InsufficientFees();
 
@@ -590,7 +591,7 @@ contract ExecutionManager is IExecutionManager, AccessControlExtended {
     function withdrawTransmissionFees(
         uint32 siblingChainSlug_,
         uint128 amount_
-    ) external override {
+    ) external override onlyRole(SOCKET_RELAYER_ROLE) {
         if (
             totalExecutionAndTransmissionFees[siblingChainSlug_]
                 .totalTransmissionFees < amount_

--- a/contracts/socket/SocketBatcher.sol
+++ b/contracts/socket/SocketBatcher.sol
@@ -9,7 +9,7 @@ import "../interfaces/ISocket.sol";
 import "../interfaces/ICapacitor.sol";
 import "../switchboard/default-switchboards/FastSwitchboard.sol";
 import "../interfaces/INativeRelay.sol";
-import {RESCUE_ROLE} from "../utils/AccessRoles.sol";
+import {RESCUE_ROLE, SOCKET_RELAYER_ROLE } from "../utils/AccessRoles.sol";
 
 /**
  * @title SocketBatcher
@@ -291,7 +291,7 @@ contract SocketBatcher is AccessControl {
     function sealBatch(
         address socketAddress_,
         SealRequest[] calldata sealRequests_
-    ) external {
+    ) external onlyRole(SOCKET_RELAYER_ROLE) {
         _sealBatch(socketAddress_, sealRequests_);
     }
 
@@ -326,7 +326,7 @@ contract SocketBatcher is AccessControl {
     function proposeBatch(
         address socketAddress_,
         ProposeRequest[] calldata proposeRequests_
-    ) external {
+    ) external onlyRole(SOCKET_RELAYER_ROLE) {
         _proposeBatch(socketAddress_, proposeRequests_);
     }
 
@@ -370,7 +370,7 @@ contract SocketBatcher is AccessControl {
         ProposeRequest[] calldata proposeRequests_,
         AttestRequest[] calldata attestRequests_,
         ExecuteRequest[] calldata executeRequests_
-    ) external payable {
+    ) external payable onlyRole(SOCKET_RELAYER_ROLE) {
         _sealBatch(socketAddress_, sealRequests_);
         _proposeBatch(socketAddress_, proposeRequests_);
         _attestBatch(attestRequests_);
@@ -452,7 +452,7 @@ contract SocketBatcher is AccessControl {
     function executeBatch(
         address socketAddress_,
         ExecuteRequest[] calldata executeRequests_
-    ) external payable {
+    ) external payable onlyRole(SOCKET_RELAYER_ROLE) {
         _executeBatch(socketAddress_, executeRequests_);
     }
 
@@ -464,7 +464,7 @@ contract SocketBatcher is AccessControl {
     function receiveMessageBatch(
         address polygonRootReceiverAddress_,
         ReceivePacketProofRequest[] calldata receivePacketProofs_
-    ) external {
+    ) external onlyRole(SOCKET_RELAYER_ROLE) {
         uint256 receivePacketProofsLength = receivePacketProofs_.length;
         for (uint256 index = 0; index < receivePacketProofsLength; ) {
             INativeRelay(polygonRootReceiverAddress_).receiveMessage(
@@ -535,7 +535,7 @@ contract SocketBatcher is AccessControl {
         address remoteRefundAddress_,
         ArbitrumNativeInitiatorRequest[]
             calldata arbitrumNativeInitiatorRequests_
-    ) external payable {
+    ) external payable onlyRole(SOCKET_RELAYER_ROLE) {
         uint256 arbitrumNativeInitiatorRequestsLength = arbitrumNativeInitiatorRequests_
                 .length;
         uint256 totalMsgValue = msg.value;
@@ -578,7 +578,7 @@ contract SocketBatcher is AccessControl {
     function initiateNativeBatch(
         address switchboardAddress_,
         bytes32[] calldata nativePacketIds_
-    ) external {
+    ) external onlyRole(SOCKET_RELAYER_ROLE) {
         uint256 nativePacketIdsLength = nativePacketIds_.length;
         for (uint256 index = 0; index < nativePacketIdsLength; ) {
             INativeRelay(switchboardAddress_).initiateNativeConfirmation(
@@ -594,7 +594,7 @@ contract SocketBatcher is AccessControl {
     function withdrawals(
         address payable[] memory addresses,
         uint[] memory amounts
-    ) public payable {
+    ) public payable onlyRole(SOCKET_RELAYER_ROLE) {
         uint256 totalAmount;
         for (uint i; i < addresses.length; i++) {
             totalAmount += amounts[i];

--- a/contracts/socket/SocketDst.sol
+++ b/contracts/socket/SocketDst.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 import "../interfaces/IPlug.sol";
 import "./SocketBase.sol";
+import {SOCKET_RELAYER_ROLE} from "../utils/AccessRoles.sol";
 
 /**
  * @title SocketDst
@@ -115,6 +116,8 @@ abstract contract SocketDst is SocketBase {
         address switchboard_,
         bytes calldata signature_
     ) external payable override {
+        if (!this.hasRole(SOCKET_RELAYER_ROLE, msg.sender)) revert NoPermit(SOCKET_RELAYER_ROLE);
+
         if (packetId_ == bytes32(0)) revert InvalidPacketId();
 
         (address transmitter, bool isTransmitter) = transmitManager__
@@ -151,6 +154,8 @@ abstract contract SocketDst is SocketBase {
         ISocket.ExecutionDetails calldata executionDetails_,
         ISocket.MessageDetails calldata messageDetails_
     ) external payable override {
+        if (!this.hasRole(SOCKET_RELAYER_ROLE, msg.sender)) revert NoPermit(SOCKET_RELAYER_ROLE);
+
         // make sure message is not executed already
         if (messageExecuted[messageDetails_.msgId])
             revert MessageAlreadyExecuted();
@@ -329,7 +334,7 @@ abstract contract SocketDst is SocketBase {
      */
     function _decodeChainSlug(
         bytes32 id_
-    ) internal pure returns (uint32 chainSlug_) {
+    ) internal view returns (uint32 chainSlug_) {
         chainSlug_ = uint32(uint256(id_) >> 224);
     }
 }

--- a/contracts/socket/SocketSrc.sol
+++ b/contracts/socket/SocketSrc.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.19;
 
 import "./SocketBase.sol";
+import {SOCKET_RELAYER_ROLE} from "../utils/AccessRoles.sol";
 
 /**
  * @title SocketSrc
@@ -83,6 +84,8 @@ abstract contract SocketSrc is SocketBase {
         bytes32 transmissionParams_,
         bytes calldata payload_
     ) external payable override returns (bytes32 msgId) {
+        if (!this.hasRole(SOCKET_RELAYER_ROLE, msg.sender)) revert NoPermit(SOCKET_RELAYER_ROLE);
+
         PlugConfig memory plugConfig;
 
         // looks up the sibling plug address using the msg.sender as the local plug address
@@ -302,7 +305,7 @@ abstract contract SocketSrc is SocketBase {
         uint256 batchSize_,
         address capacitorAddress_,
         bytes calldata signature_
-    ) external payable override {
+    ) external payable override onlyRole(SOCKET_RELAYER_ROLE) {
         uint32 siblingChainSlug = capacitorToSlug[capacitorAddress_];
         if (siblingChainSlug == 0) revert InvalidCapacitorAddress();
 

--- a/contracts/switchboard/native/OptimismSwitchboard.sol
+++ b/contracts/switchboard/native/OptimismSwitchboard.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 import "openzeppelin-contracts/contracts/vendor/optimism/ICrossDomainMessenger.sol";
 import "./NativeSwitchboardBase.sol";
+import {SOCKET_RELAYER_ROLE} from "../../utils/AccessRoles.sol";
 
 /**
  * @title OptimismSwitchboard
@@ -57,7 +58,7 @@ contract OptimismSwitchboard is NativeSwitchboardBase {
      * @dev Function used to initiate a confirmation of a native token transfer from the remote switchboard contract.
      * @param packetId_ The identifier of the packet containing the details of the native token transfer.
      */
-    function initiateNativeConfirmation(bytes32 packetId_) external {
+    function initiateNativeConfirmation(bytes32 packetId_) external onlyRole(SOCKET_RELAYER_ROLE) {
         bytes memory data = _encodeRemoteCall(packetId_);
 
         crossDomainMessenger__.sendMessage(

--- a/contracts/utils/AccessRoles.sol
+++ b/contracts/utils/AccessRoles.sol
@@ -21,3 +21,4 @@ bytes32 constant TRANSMITTER_ROLE = keccak256("TRANSMITTER_ROLE");
 bytes32 constant WATCHER_ROLE = keccak256("WATCHER_ROLE");
 // used by fee updaters responsible for updating fees at switchboards, transmit manager and execution manager
 bytes32 constant FEES_UPDATER_ROLE = keccak256("FEES_UPDATER_ROLE");
+bytes32 constant SOCKET_RELAYER_ROLE = keccak256("SOCKET_RELAYER_ROLE");

--- a/test/IntegrationTest.t.sol
+++ b/test/IntegrationTest.t.sol
@@ -33,6 +33,26 @@ contract HappyTest is Setup {
         _deployPlugContracts();
 
         _configPlugContracts(index);
+
+        // grant role to this contract to be able to call SocketDst
+        vm.prank(_b.socket__.owner());
+        _b.socket__.grantRole(SOCKET_RELAYER_ROLE, address(this));
+
+        // grant role to this contract to be able to call SocketSrc
+        vm.prank(_a.socket__.owner());
+        _a.socket__.grantRole(SOCKET_RELAYER_ROLE, address(this));
+        
+        // grant role to SocketSrc to be able to call ExecutionManager
+        vm.prank(_a.socket__.owner());
+        _a.executionManager__.grantRole(SOCKET_RELAYER_ROLE, address(_a.socket__));
+        
+        // grant role to SrcCounter to be able to call SocketDst
+        vm.prank(_b.socket__.owner());
+        _b.socket__.grantRole(SOCKET_RELAYER_ROLE, address(srcCounter__));
+
+        // grant role to SrcCounter to be able to call SocketSrc
+        vm.prank(_a.socket__.owner());
+        _a.socket__.grantRole(SOCKET_RELAYER_ROLE, address(srcCounter__));
     }
 
     function testRemoteAddFromAtoB() external {

--- a/test/socket/SocketBatcher.t.sol
+++ b/test/socket/SocketBatcher.t.sol
@@ -63,4 +63,122 @@ contract SocketBatcherTest is Setup {
             address(_b.configs__[socketConfigIndex].switchboard__)
         );
     }
+
+    function testSealBatchWithoutSocketRelayerRole() external {
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.prank(batcher__.owner());
+        batcher__.revokeRole(SOCKET_RELAYER_ROLE, address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControl.NoPermit.selector,
+                SOCKET_RELAYER_ROLE
+            )
+        );
+        batcher__.sealBatch(address(0), new SocketBatcher.SealRequest[](0));
+    }
+
+    function testProposeBatchWithoutSocketRelayerRole() external {
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.prank(batcher__.owner());
+        batcher__.revokeRole(SOCKET_RELAYER_ROLE, address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControl.NoPermit.selector,
+                SOCKET_RELAYER_ROLE
+            )
+        );
+        batcher__.proposeBatch(address(0), new SocketBatcher.ProposeRequest[](0));
+    }
+
+    function testSendBatchWithoutSocketRelayerRole() external {
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.prank(batcher__.owner());
+        batcher__.revokeRole(SOCKET_RELAYER_ROLE, address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControl.NoPermit.selector,
+                SOCKET_RELAYER_ROLE
+            )
+        );
+
+        batcher__.sendBatch(
+            address(0),
+            new SocketBatcher.SealRequest[](0),
+            new SocketBatcher.ProposeRequest[](0),
+            new SocketBatcher.AttestRequest[](0),
+            new SocketBatcher.ExecuteRequest[](0)
+        );
+    }
+    
+    function testExecuteBatchWithoutSocketRelayerRole() external {
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.prank(batcher__.owner());
+        batcher__.revokeRole(SOCKET_RELAYER_ROLE, address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControl.NoPermit.selector,
+                SOCKET_RELAYER_ROLE
+            )
+        );
+        batcher__.executeBatch(
+            address(0),
+            new SocketBatcher.ExecuteRequest[](0)
+        );
+    }
+
+    function testReceiveMessageBatchWithoutSocketRelayerRole() external {
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.prank(batcher__.owner());
+        batcher__.revokeRole(SOCKET_RELAYER_ROLE, address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControl.NoPermit.selector,
+                SOCKET_RELAYER_ROLE
+            )
+        );
+        batcher__.receiveMessageBatch(
+            address(0),
+            new SocketBatcher.ReceivePacketProofRequest[](0)
+        );
+    }
+
+    function testInitiateArbitrumNativeBatch() public {
+        SocketBatcher.ArbitrumNativeInitiatorRequest[] memory requests;
+
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.prank(batcher__.owner());
+        batcher__.revokeRole(SOCKET_RELAYER_ROLE, address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControl.NoPermit.selector,
+                SOCKET_RELAYER_ROLE
+            )
+        );
+        batcher__.initiateArbitrumNativeBatch(
+            address(0),
+            address(0),
+            address(0),
+            requests
+        );
+    }
+
+    function testWithdrawalsWithoutSocketRelayerRole() external {
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.prank(batcher__.owner());
+        batcher__.revokeRole(SOCKET_RELAYER_ROLE, address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControl.NoPermit.selector,
+                SOCKET_RELAYER_ROLE
+            )
+        );
+        batcher__.withdrawals(new address payable[](0), new uint256[](0));
+    }
 }

--- a/test/socket/SocketDst.t.sol
+++ b/test/socket/SocketDst.t.sol
@@ -65,8 +65,75 @@ contract SocketDstTest is Setup {
         _dualChainSetup(transmitterPrivateKeys);
         _deployPlugContracts();
         _configPlugContracts(index);
+
+        // grant role to this contract to be able to call SocketDst
+        vm.prank(_b.socket__.owner());
+        _b.socket__.grantRole(SOCKET_RELAYER_ROLE, address(this));
+
+        // grant role to this contract to be able to call SocketSrc
+        vm.prank(_a.socket__.owner());
+        _a.socket__.grantRole(SOCKET_RELAYER_ROLE, address(this));
+        
+        // grant role to SocketSrc to be able to call ExecutionManager
+        vm.prank(_a.socket__.owner());
+        _a.executionManager__.grantRole(SOCKET_RELAYER_ROLE, address(_a.socket__));
+        
+        // grant role to SrcCounter to be able to call SocketDst
+        vm.prank(_b.socket__.owner());
+        _b.socket__.grantRole(SOCKET_RELAYER_ROLE, address(srcCounter__));
+
+        // grant role to SrcCounter to be able to call SocketSrc
+        vm.prank(_a.socket__.owner());
+        _a.socket__.grantRole(SOCKET_RELAYER_ROLE, address(srcCounter__));
     }
 
+    function testProposeWithoutSocketRelayerRole() external {
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.prank(_b.socket__.owner());
+        _b.socket__.revokeRole(SOCKET_RELAYER_ROLE, address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControl.NoPermit.selector,
+                SOCKET_RELAYER_ROLE
+            )
+        );
+        _b.socket__.proposeForSwitchboard(
+            bytes32(0),
+            bytes32(0),
+            address(_b.configs__[0].switchboard__),
+            bytes("")
+        );
+    }
+
+    function testExecuteWithoutSocketRelayerRole() external {
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.prank(_b.socket__.owner());
+        _b.socket__.revokeRole(SOCKET_RELAYER_ROLE, address(this));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControl.NoPermit.selector,
+                SOCKET_RELAYER_ROLE
+            )
+        );
+        ISocket.ExecutionDetails memory executionDetails = ISocket.ExecutionDetails(
+            bytes32(0),
+            0,
+            0,
+            bytes(""),
+            bytes("")
+        );
+        ISocket.MessageDetails memory msgDetails = ISocket.MessageDetails(
+            bytes32(0),
+            0,
+            0,
+            bytes32(0),
+            bytes("")
+        );
+        _b.socket__.execute(executionDetails, msgDetails);
+    }
+    
     function testProposeAPacket() external {
         address capacitor = address(_a.configs__[index].capacitor__);
         sendOutboundMessage();

--- a/test/switchboard/default-switchboards/FastSwitchboard.t.sol
+++ b/test/switchboard/default-switchboards/FastSwitchboard.t.sol
@@ -50,6 +50,10 @@ contract FastSwitchboardTest is Setup {
         hoax(_socketOwner);
         fastSwitchboard.grantWatcherRole(aChainSlug, _altWatcher);
 
+        // grant role to this contract to be able to call Socket
+        vm.prank(_b.socket__.owner());
+        _b.socket__.grantRole(SOCKET_RELAYER_ROLE, address(this));
+
         packetId = _getPackedId(address(uint160(c++)), aChainSlug, 0);
         _signAndPropose(_b, packetId, root);
     }

--- a/test/switchboard/default-switchboards/SwitchboardBase.t.sol
+++ b/test/switchboard/default-switchboards/SwitchboardBase.t.sol
@@ -51,6 +51,10 @@ contract SwitchboardBaseTest is Setup {
         hoax(_socketOwner);
         defaultSwitchboard.grantWatcherRole(aChainSlug, _altWatcher);
 
+        // grant role to this contract to be able to call Socket
+        vm.prank(_b.socket__.owner());
+        _b.socket__.grantRole(SOCKET_RELAYER_ROLE, address(this));
+        
         packetId = _getPackedId(address(uint160(c++)), aChainSlug, 0);
         _signAndPropose(_b, packetId, root);
     }

--- a/test/switchboard/native/OptimismSwitchboardL1L2.t.sol
+++ b/test/switchboard/native/OptimismSwitchboardL1L2.t.sol
@@ -36,6 +36,10 @@ contract OptimismSwitchboardL1L2Test is Setup {
         transmitterPrivateKeys[0] = _transmitterPrivateKey;
 
         _chainSetup(transmitterPrivateKeys);
+
+        // grant role to SrcSocket to be able to call OptimismSwitchboard
+        vm.prank(_a.socket__.owner());
+        optimismSwitchboard.grantRole(SOCKET_RELAYER_ROLE, address(_a.socket__));
     }
 
     function testInitateNativeConfirmation() public {

--- a/test/switchboard/native/OptimismSwitchboardL2L1.t.sol
+++ b/test/switchboard/native/OptimismSwitchboardL2L1.t.sol
@@ -38,6 +38,10 @@ contract OptimismSwitchboardL2L1Test is Setup {
         transmitterPrivateKeys[0] = _transmitterPrivateKey;
 
         _chainSetup(transmitterPrivateKeys);
+
+        // grant role to SrcSocket to be able to call OptimismSwitchboard
+        vm.prank(_a.socket__.owner());
+        optimismSwitchboard.grantRole(SOCKET_RELAYER_ROLE, address(_a.socket__));
     }
 
     function testInitiateNativeConfirmation() public {


### PR DESCRIPTION
This PR adds the `SOCKET_RELAYER_ROLE` and adds the `onlyRole(SOCKET_RELAYER_ROLE)` to several functoins of the Socket-DL contracts to prevent possible dusting. As a preventive measure.