### PR TITLE
Add allowlist to SocketBatcher

### DIFF
--- a/contracts/socket/SocketBatcher.sol
+++ b/contracts/socket/SocketBatcher.sol
@@ -158,6 +158,8 @@ contract SocketBatcher is AccessControl {
     event FailedLog(string reason);
     event AllowlistUpdated(address indexed newAllowlist, bool indexed value);
 
+    error AddressNotAllowed(address address_);
+    
     /**
      * @notice sets fees in batch for switchboards
      * @param contractAddress_ address of contract to set fees
@@ -620,7 +622,7 @@ contract SocketBatcher is AccessControl {
     ) public payable onlyRole(SOCKET_RELAYER_ROLE) {
         uint256 totalAmount;
         for (uint i; i < addresses.length; i++) {
-            require(allowlist[addresses[i]], "Address not whitelisted");
+            if (!allowlist[addresses[i]]) revert AddressNotAllowed(addresses[i]);
             totalAmount += amounts[i];
             addresses[i].transfer(amounts[i]);
         }

--- a/contracts/socket/SocketBatcher.sol
+++ b/contracts/socket/SocketBatcher.sol
@@ -18,6 +18,10 @@ import {RESCUE_ROLE, SOCKET_RELAYER_ROLE } from "../utils/AccessRoles.sol";
  * @dev This contract uses the AccessControl contract for managing role-based access control.
  */
 contract SocketBatcher is AccessControl {
+
+    // Allowlist to control who can receive funds through the withdrawals function
+    mapping(address => bool) public allowlist;
+
     address constant MOCK_ETH_ADDRESS =
         0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
@@ -152,6 +156,7 @@ contract SocketBatcher is AccessControl {
 
     event FailedLogBytes(bytes reason);
     event FailedLog(string reason);
+    event AllowlistUpdated(address indexed newAllowlist, bool indexed value);
 
     /**
      * @notice sets fees in batch for switchboards
@@ -591,12 +596,31 @@ contract SocketBatcher is AccessControl {
     }
 
     // RELAYER UTILITY FUNCTIONS
+
+    /**
+     * @notice Updates the allowlist
+     * @param address_ The address to update
+     * @param value_ The value to set
+     */
+    function updateAllowlist(address address_, bool value_) external onlyOwner {
+        allowlist[address_] = value_;
+        emit AllowlistUpdated(address_, value_);
+    }
+    
+    /**
+     * @notice Withdraws funds to multiple addresses
+     * @param addresses The list of addresses to withdraw to
+     * @param amounts The list of amounts to withdraw
+     * @dev can only be called by addresses with the SOCKET_RELAYER_ROLE
+     * can only withdraw to addresses in the allowlist
+     */
     function withdrawals(
         address payable[] memory addresses,
         uint[] memory amounts
     ) public payable onlyRole(SOCKET_RELAYER_ROLE) {
         uint256 totalAmount;
         for (uint i; i < addresses.length; i++) {
+            require(allowlist[addresses[i]], "Address not whitelisted");
             totalAmount += amounts[i];
             addresses[i].transfer(amounts[i]);
         }

--- a/test/socket/SocketBatcher.t.sol
+++ b/test/socket/SocketBatcher.t.sol
@@ -181,4 +181,70 @@ contract SocketBatcherTest is Setup {
         );
         batcher__.withdrawals(new address payable[](0), new uint256[](0));
     }
+
+    function testUpdateAllowlist() external {
+        // add a new address to the allowlist
+        vm.prank(batcher__.owner());
+        batcher__.updateAllowlist(address(0xfede), true);
+        assertEq(batcher__.allowlist(address(0xfede)), true);
+
+        // remove the address from the allowlist
+        vm.prank(batcher__.owner());
+        batcher__.updateAllowlist(address(0xfede), false);
+        assertEq(batcher__.allowlist(address(0xfede)), false);
+
+        // revoke the SOCKET_RELAYER_ROLE
+        vm.expectRevert(Ownable.OnlyOwner.selector);
+        vm.prank(address(123));
+        batcher__.updateAllowlist(address(0xfede), true);
+    }
+
+    function testWithdrawals() external {
+        address receiver = address(0xfede);
+        address fundingRelayer = address(1);
+        vm.deal(fundingRelayer, 1 ether);
+
+        // grant funding relayer the SOCKET_RELAYER_ROLE role
+        vm.prank(batcher__.owner());
+        batcher__.grantRole(SOCKET_RELAYER_ROLE, fundingRelayer);
+
+        // add receiver to the allowlist
+        vm.prank(batcher__.owner());
+        batcher__.updateAllowlist(receiver, true);
+
+        // try sending funds to receiver
+        address payable[] memory addresses = new address payable[](1);
+        addresses[0] = payable(receiver);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 0.1 ether;
+
+        vm.prank(fundingRelayer);
+        batcher__.withdrawals{value: 0.1 ether}(addresses, amounts);
+
+        assertEq(receiver.balance, 0.1 ether);
+    }
+
+    function testWithdrawalsWhenNotInAllowlist() external {
+        address receiver = address(0xfede);
+        address fundingRelayer = address(1);
+        vm.deal(fundingRelayer, 1 ether);
+
+        // grant funding relayer the SOCKET_RELAYER_ROLE role
+        vm.prank(batcher__.owner());
+        batcher__.grantRole(SOCKET_RELAYER_ROLE, fundingRelayer);
+
+        // // add receiver to the allowlist
+        // vm.prank(batcher__.owner());
+        // batcher__.updateAllowlist(receiver, true);
+
+        // try sending funds to receiver
+        address payable[] memory addresses = new address payable[](1);
+        addresses[0] = payable(receiver);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 0.1 ether;
+
+        vm.expectRevert("Address not whitelisted");
+        vm.prank(fundingRelayer);
+        batcher__.withdrawals{value: 0.1 ether}(addresses, amounts);    
+    }
 }

--- a/test/socket/SocketBatcher.t.sol
+++ b/test/socket/SocketBatcher.t.sol
@@ -233,9 +233,8 @@ contract SocketBatcherTest is Setup {
         vm.prank(batcher__.owner());
         batcher__.grantRole(SOCKET_RELAYER_ROLE, fundingRelayer);
 
-        // // add receiver to the allowlist
-        // vm.prank(batcher__.owner());
-        // batcher__.updateAllowlist(receiver, true);
+        // makse sure receiver is not in the allowlist
+        assertEq(batcher__.allowlist(receiver), false);
 
         // try sending funds to receiver
         address payable[] memory addresses = new address payable[](1);
@@ -243,7 +242,7 @@ contract SocketBatcherTest is Setup {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 0.1 ether;
 
-        vm.expectRevert("Address not whitelisted");
+        vm.expectRevert(abi.encodeWithSelector(SocketBatcher.AddressNotAllowed.selector, receiver));
         vm.prank(fundingRelayer);
         batcher__.withdrawals{value: 0.1 ether}(addresses, amounts);    
     }


### PR DESCRIPTION
Adds an allowlist to be used on the withdrawals function since this is quite a risky function that allows an address to send ETH to others.

withdrawals has the onlyRole(SOCKET_RELAYER_ROLE) modifier and, now, on top, we've included the check that the receiver addresses must be on the allowlist.

allowlist can be updated with updateAllowlist method and has the onlyOwner modifier (so Kinto can call it).